### PR TITLE
Raw filenames as argument to get_thumbnail

### DIFF
--- a/thumbnail/backend.py
+++ b/thumbnail/backend.py
@@ -44,8 +44,8 @@ class AsyncThumbnailBackend(ThumbnailBackend):
             # don't make it easy to.
             rawvalue = default.kvstore._get_raw(add_prefix(thumbnail.key))
             rawvaluearr = deserialize(rawvalue)
-            rawvaluearr['name'] = file_.name
+            rawvaluearr['name'] = source.name
             default.kvstore._set_raw(add_prefix(thumbnail.key), serialize(rawvaluearr))
         
-        thumbnail.name = file_.name
+        thumbnail.name = source.name
         return thumbnail


### PR DESCRIPTION
Hi!

sorl-thumbnail master supports this kind of thing:
```
>>> from sorl.thumbnail import get_thumbnail
>>> get_thumbnail('images/image.png', '570')
<sorl.thumbnail.images.ImageFile object at 0x1066bd750>
```

But on sorl-thumbnail-async, we get an `AttributeError`:
```
>>> from sorl.thumbnail import get_thumbnail
>>> get_thumbnail('images/image.png', '570')
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/Users/austin/.virtualenvs/project/lib/python2.7/site-packages/sorl/thumbnail/shortcuts.py", line 8, in get_thumbnail
    return default.backend.get_thumbnail(file_, geometry_string, **options)
  File "/Users/austin/.virtualenvs/project/lib/python2.7/site-packages/thumbnail/backend.py", line 47, in get_thumbnail
    rawvaluearr['name'] = file_.name
AttributeError: 'str' object has no attribute 'name'
```

Sorl's `ImageFile`  [checks if we're dealing with a file field or a string](https://github.com/mariocesar/sorl-thumbnail/blob/master/sorl/thumbnail/images.py#L86-L90):
```
        # figure out name
        if hasattr(file_, 'name'):
            self.name = file_.name
        else:
            self.name = force_unicode(file_)
```

Which is why using `source`, based on the ImageFile, rather than `file_` itself, gets rid of the attribute error:
```
>>> from sorl.thumbnail import get_thumbnail
>>> get_thumbnail('images/image.png', '570')
<sorl.thumbnail.images.ImageFile object at 0x106ab5190>
```

Two tiny changes, to backend.py, that's all (see below)!
Anyway, thanks for putting this fork together, you've made our lives much simpler.